### PR TITLE
added NBits to Boolean and Byte datatype

### DIFF
--- a/de.oaam.model.edit/plugin.properties
+++ b/de.oaam.model.edit/plugin.properties
@@ -916,3 +916,5 @@ _UI_Message_sourceDevices_feature = Source Devices
 _UI_Message_destinationDevices_feature = Destination Devices
 _UI_Byte_nBits_feature = NBits
 _UI_Boolean_nBits_feature = NBits
+_UI_MessageA_isPersistent_feature = Is Persistent
+_UI_MessageA_length_feature = Length

--- a/de.oaam.model.edit/plugin.properties
+++ b/de.oaam.model.edit/plugin.properties
@@ -914,3 +914,5 @@ _UI_MessageType_alignment_feature = Alignment
 _UI_MessageA_type_feature = Type
 _UI_Message_sourceDevices_feature = Source Devices
 _UI_Message_destinationDevices_feature = Destination Devices
+_UI_Byte_nBits_feature = NBits
+_UI_Boolean_nBits_feature = NBits

--- a/de.oaam.model.edit/src/de/oaam/model/oaam/allocations/provider/MessageAItemProvider.java
+++ b/de.oaam.model.edit/src/de/oaam/model/oaam/allocations/provider/MessageAItemProvider.java
@@ -26,6 +26,7 @@ import org.eclipse.emf.ecore.EStructuralFeature;
 
 import org.eclipse.emf.edit.provider.ComposeableAdapterFactory;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
+import org.eclipse.emf.edit.provider.ItemPropertyDescriptor;
 import org.eclipse.emf.edit.provider.ViewerNotification;
 
 /**
@@ -58,6 +59,8 @@ public class MessageAItemProvider extends OaamBaseElementAItemProvider {
 
 			addVariantsPropertyDescriptor(object);
 			addTypePropertyDescriptor(object);
+			addIsPersistentPropertyDescriptor(object);
+			addLengthPropertyDescriptor(object);
 		}
 		return itemPropertyDescriptors;
 	}
@@ -102,6 +105,50 @@ public class MessageAItemProvider extends OaamBaseElementAItemProvider {
 				 false,
 				 true,
 				 null,
+				 null,
+				 null));
+	}
+
+	/**
+	 * This adds a property descriptor for the Is Persistent feature.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	protected void addIsPersistentPropertyDescriptor(Object object) {
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_MessageA_isPersistent_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_MessageA_isPersistent_feature", "_UI_MessageA_type"),
+				 AllocationsPackage.Literals.MESSAGE_A__IS_PERSISTENT,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.BOOLEAN_VALUE_IMAGE,
+				 null,
+				 null));
+	}
+
+	/**
+	 * This adds a property descriptor for the Length feature.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	protected void addLengthPropertyDescriptor(Object object) {
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_MessageA_length_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_MessageA_length_feature", "_UI_MessageA_type"),
+				 AllocationsPackage.Literals.MESSAGE_A__LENGTH,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.INTEGRAL_VALUE_IMAGE,
 				 null,
 				 null));
 	}
@@ -178,6 +225,10 @@ public class MessageAItemProvider extends OaamBaseElementAItemProvider {
 		updateChildren(notification);
 
 		switch (notification.getFeatureID(MessageA.class)) {
+			case AllocationsPackage.MESSAGE_A__IS_PERSISTENT:
+			case AllocationsPackage.MESSAGE_A__LENGTH:
+				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
+				return;
 			case AllocationsPackage.MESSAGE_A__OPERATION_MODES:
 			case AllocationsPackage.MESSAGE_A__SCHEDULES:
 			case AllocationsPackage.MESSAGE_A__SUBMESSAGES:

--- a/de.oaam.model.edit/src/de/oaam/model/oaam/common/provider/BooleanItemProvider.java
+++ b/de.oaam.model.edit/src/de/oaam/model/oaam/common/provider/BooleanItemProvider.java
@@ -3,13 +3,17 @@
 package de.oaam.model.oaam.common.provider;
 
 
+import de.oaam.model.oaam.common.CommonPackage;
 import java.util.Collection;
 import java.util.List;
 
 import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.common.notify.Notification;
 
+import org.eclipse.emf.edit.provider.ComposeableAdapterFactory;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
+import org.eclipse.emf.edit.provider.ItemPropertyDescriptor;
+import org.eclipse.emf.edit.provider.ViewerNotification;
 
 /**
  * This is the item provider adapter for a {@link de.oaam.model.oaam.common.Boolean} object.
@@ -39,8 +43,31 @@ public class BooleanItemProvider extends DataTypeAItemProvider {
 		if (itemPropertyDescriptors == null) {
 			super.getPropertyDescriptors(object);
 
+			addNBitsPropertyDescriptor(object);
 		}
 		return itemPropertyDescriptors;
+	}
+
+	/**
+	 * This adds a property descriptor for the NBits feature.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	protected void addNBitsPropertyDescriptor(Object object) {
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_Boolean_nBits_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_Boolean_nBits_feature", "_UI_Boolean_type"),
+				 CommonPackage.Literals.BOOLEAN__NBITS,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.INTEGRAL_VALUE_IMAGE,
+				 null,
+				 null));
 	}
 
 	/**
@@ -79,6 +106,12 @@ public class BooleanItemProvider extends DataTypeAItemProvider {
 	@Override
 	public void notifyChanged(Notification notification) {
 		updateChildren(notification);
+
+		switch (notification.getFeatureID(de.oaam.model.oaam.common.Boolean.class)) {
+			case CommonPackage.BOOLEAN__NBITS:
+				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
+				return;
+		}
 		super.notifyChanged(notification);
 	}
 

--- a/de.oaam.model.edit/src/de/oaam/model/oaam/common/provider/ByteItemProvider.java
+++ b/de.oaam.model.edit/src/de/oaam/model/oaam/common/provider/ByteItemProvider.java
@@ -3,13 +3,17 @@
 package de.oaam.model.oaam.common.provider;
 
 
+import de.oaam.model.oaam.common.CommonPackage;
 import java.util.Collection;
 import java.util.List;
 
 import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.common.notify.Notification;
 
+import org.eclipse.emf.edit.provider.ComposeableAdapterFactory;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
+import org.eclipse.emf.edit.provider.ItemPropertyDescriptor;
+import org.eclipse.emf.edit.provider.ViewerNotification;
 
 /**
  * This is the item provider adapter for a {@link de.oaam.model.oaam.common.Byte} object.
@@ -39,8 +43,31 @@ public class ByteItemProvider extends DataTypeAItemProvider {
 		if (itemPropertyDescriptors == null) {
 			super.getPropertyDescriptors(object);
 
+			addNBitsPropertyDescriptor(object);
 		}
 		return itemPropertyDescriptors;
+	}
+
+	/**
+	 * This adds a property descriptor for the NBits feature.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	protected void addNBitsPropertyDescriptor(Object object) {
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_Byte_nBits_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_Byte_nBits_feature", "_UI_Byte_type"),
+				 CommonPackage.Literals.BYTE__NBITS,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.INTEGRAL_VALUE_IMAGE,
+				 null,
+				 null));
 	}
 
 	/**
@@ -79,6 +106,12 @@ public class ByteItemProvider extends DataTypeAItemProvider {
 	@Override
 	public void notifyChanged(Notification notification) {
 		updateChildren(notification);
+
+		switch (notification.getFeatureID(de.oaam.model.oaam.common.Byte.class)) {
+			case CommonPackage.BYTE__NBITS:
+				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
+				return;
+		}
 		super.notifyChanged(notification);
 	}
 

--- a/de.oaam.model/model/oaam.ecore
+++ b/de.oaam.model/model/oaam.ecore
@@ -349,6 +349,12 @@
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="8 Bits of unknown content"/>
       </eAnnotations>
+      <eStructuralFeatures xsi:type="ecore:EAttribute" name="nBits" lowerBound="1"
+          eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt" defaultValueLiteral="8">
+        <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+          <details key="documentation" value="The number of character encoding bits. The default is 8."/>
+        </eAnnotations>
+      </eStructuralFeatures>
     </eClassifiers>
     <eClassifiers xsi:type="ecore:EClass" name="Character" eSuperTypes="#//common/DataTypeA">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -386,6 +392,12 @@
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="A Boolean value, i.e. true or false."/>
       </eAnnotations>
+      <eStructuralFeatures xsi:type="ecore:EAttribute" name="nBits" lowerBound="1"
+          eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt" defaultValueLiteral="1">
+        <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+          <details key="documentation" value="The number of character encoding bits. The default is 8."/>
+        </eAnnotations>
+      </eStructuralFeatures>
     </eClassifiers>
   </eSubpackages>
   <eSubpackages name="library" nsURI="http://www.oaam.de/oaam/model/v140/library"

--- a/de.oaam.model/model/oaam.ecore
+++ b/de.oaam.model/model/oaam.ecore
@@ -4023,6 +4023,16 @@
           <details key="documentation" value="Defines type of this message"/>
         </eAnnotations>
       </eStructuralFeatures>
+      <eStructuralFeatures xsi:type="ecore:EAttribute" name="isPersistent" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean">
+        <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+          <details key="documentation" value="If set, message will not be altered in any way. Typically used for messages from complex sensors."/>
+        </eAnnotations>
+      </eStructuralFeatures>
+      <eStructuralFeatures xsi:type="ecore:EAttribute" name="length" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt">
+        <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+          <details key="documentation" value="Defines length of this message"/>
+        </eAnnotations>
+      </eStructuralFeatures>
     </eClassifiers>
     <eClassifiers xsi:type="ecore:EClass" name="MessageSegment" eSuperTypes="#//common/OaamBaseElementA #//scenario/VariantDependentElementA #//scenario/ModeDependentElementA">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">

--- a/de.oaam.model/model/oaam.genmodel
+++ b/de.oaam.model/model/oaam.genmodel
@@ -95,12 +95,16 @@
         <genFeatures createChild="false" ecoreFeature="ecore:EAttribute oaam.ecore#//common/FloatingPoint/nBits"/>
         <genFeatures createChild="false" ecoreFeature="ecore:EAttribute oaam.ecore#//common/FloatingPoint/endianess"/>
       </genClasses>
-      <genClasses ecoreClass="oaam.ecore#//common/Byte"/>
+      <genClasses ecoreClass="oaam.ecore#//common/Byte">
+        <genFeatures createChild="false" ecoreFeature="ecore:EAttribute oaam.ecore#//common/Byte/nBits"/>
+      </genClasses>
       <genClasses ecoreClass="oaam.ecore#//common/Character">
         <genFeatures createChild="false" ecoreFeature="ecore:EAttribute oaam.ecore#//common/Character/encoding"/>
         <genFeatures createChild="false" ecoreFeature="ecore:EAttribute oaam.ecore#//common/Character/nBits"/>
       </genClasses>
-      <genClasses ecoreClass="oaam.ecore#//common/Boolean"/>
+      <genClasses ecoreClass="oaam.ecore#//common/Boolean">
+        <genFeatures createChild="false" ecoreFeature="ecore:EAttribute oaam.ecore#//common/Boolean/nBits"/>
+      </genClasses>
     </nestedGenPackages>
     <nestedGenPackages prefix="Library" basePackage="de.oaam.model.oaam" disposableProviderFactory="true"
         multipleEditorPages="false" generateModelWizard="false" ecorePackage="oaam.ecore#//library">

--- a/de.oaam.model/model/oaam.genmodel
+++ b/de.oaam.model/model/oaam.genmodel
@@ -1049,6 +1049,8 @@
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference oaam.ecore#//allocations/MessageA/segments"/>
         <genFeatures notify="false" createChild="false" propertySortChoices="true"
             ecoreFeature="ecore:EReference oaam.ecore#//allocations/MessageA/type"/>
+        <genFeatures createChild="false" ecoreFeature="ecore:EAttribute oaam.ecore#//allocations/MessageA/isPersistent"/>
+        <genFeatures createChild="false" ecoreFeature="ecore:EAttribute oaam.ecore#//allocations/MessageA/length"/>
       </genClasses>
       <genClasses ecoreClass="oaam.ecore#//allocations/MessageSegment">
         <genFeatures notify="false" createChild="false" propertySortChoices="true"

--- a/de.oaam.model/src/de/oaam/model/oaam/allocations/AllocationsPackage.java
+++ b/de.oaam.model/src/de/oaam/model/oaam/allocations/AllocationsPackage.java
@@ -1898,13 +1898,31 @@ public interface AllocationsPackage extends EPackage {
 	int MESSAGE_A__TYPE = CommonPackage.OAAM_BASE_ELEMENT_A_FEATURE_COUNT + 6;
 
 	/**
+	 * The feature id for the '<em><b>Is Persistent</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int MESSAGE_A__IS_PERSISTENT = CommonPackage.OAAM_BASE_ELEMENT_A_FEATURE_COUNT + 7;
+
+	/**
+	 * The feature id for the '<em><b>Length</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int MESSAGE_A__LENGTH = CommonPackage.OAAM_BASE_ELEMENT_A_FEATURE_COUNT + 8;
+
+	/**
 	 * The number of structural features of the '<em>Message A</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int MESSAGE_A_FEATURE_COUNT = CommonPackage.OAAM_BASE_ELEMENT_A_FEATURE_COUNT + 7;
+	int MESSAGE_A_FEATURE_COUNT = CommonPackage.OAAM_BASE_ELEMENT_A_FEATURE_COUNT + 9;
 
 	/**
 	 * The number of operations of the '<em>Message A</em>' class.
@@ -2186,6 +2204,24 @@ public interface AllocationsPackage extends EPackage {
 	int MESSAGE__TYPE = MESSAGE_A__TYPE;
 
 	/**
+	 * The feature id for the '<em><b>Is Persistent</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int MESSAGE__IS_PERSISTENT = MESSAGE_A__IS_PERSISTENT;
+
+	/**
+	 * The feature id for the '<em><b>Length</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int MESSAGE__LENGTH = MESSAGE_A__LENGTH;
+
+	/**
 	 * The feature id for the '<em><b>Capability</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -2383,6 +2419,24 @@ public interface AllocationsPackage extends EPackage {
 	 * @ordered
 	 */
 	int SUBMESSAGE__TYPE = MESSAGE_A__TYPE;
+
+	/**
+	 * The feature id for the '<em><b>Is Persistent</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int SUBMESSAGE__IS_PERSISTENT = MESSAGE_A__IS_PERSISTENT;
+
+	/**
+	 * The feature id for the '<em><b>Length</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int SUBMESSAGE__LENGTH = MESSAGE_A__LENGTH;
 
 	/**
 	 * The feature id for the '<em><b>Capability</b></em>' reference.
@@ -3696,6 +3750,28 @@ public interface AllocationsPackage extends EPackage {
 	EReference getMessageA_Type();
 
 	/**
+	 * Returns the meta object for the attribute '{@link de.oaam.model.oaam.allocations.MessageA#isIsPersistent <em>Is Persistent</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>Is Persistent</em>'.
+	 * @see de.oaam.model.oaam.allocations.MessageA#isIsPersistent()
+	 * @see #getMessageA()
+	 * @generated
+	 */
+	EAttribute getMessageA_IsPersistent();
+
+	/**
+	 * Returns the meta object for the attribute '{@link de.oaam.model.oaam.allocations.MessageA#getLength <em>Length</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>Length</em>'.
+	 * @see de.oaam.model.oaam.allocations.MessageA#getLength()
+	 * @see #getMessageA()
+	 * @generated
+	 */
+	EAttribute getMessageA_Length();
+
+	/**
 	 * Returns the factory that creates the instances of the model.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -4385,6 +4461,22 @@ public interface AllocationsPackage extends EPackage {
 		 * @generated
 		 */
 		EReference MESSAGE_A__TYPE = eINSTANCE.getMessageA_Type();
+
+		/**
+		 * The meta object literal for the '<em><b>Is Persistent</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute MESSAGE_A__IS_PERSISTENT = eINSTANCE.getMessageA_IsPersistent();
+
+		/**
+		 * The meta object literal for the '<em><b>Length</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute MESSAGE_A__LENGTH = eINSTANCE.getMessageA_Length();
 
 	}
 

--- a/de.oaam.model/src/de/oaam/model/oaam/allocations/MessageA.java
+++ b/de.oaam.model/src/de/oaam/model/oaam/allocations/MessageA.java
@@ -28,6 +28,8 @@ import org.eclipse.emf.common.util.EList;
  *   <li>{@link de.oaam.model.oaam.allocations.MessageA#getSignalToMessageAssignments <em>Signal To Message Assignments</em>}</li>
  *   <li>{@link de.oaam.model.oaam.allocations.MessageA#getSegments <em>Segments</em>}</li>
  *   <li>{@link de.oaam.model.oaam.allocations.MessageA#getType <em>Type</em>}</li>
+ *   <li>{@link de.oaam.model.oaam.allocations.MessageA#isIsPersistent <em>Is Persistent</em>}</li>
+ *   <li>{@link de.oaam.model.oaam.allocations.MessageA#getLength <em>Length</em>}</li>
  * </ul>
  *
  * @see de.oaam.model.oaam.allocations.AllocationsPackage#getMessageA()
@@ -119,5 +121,55 @@ public interface MessageA extends OaamBaseElementA, VariantDependentElementA, Mo
 	 * @generated
 	 */
 	void setType(MessageType value);
+
+	/**
+	 * Returns the value of the '<em><b>Is Persistent</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * If set, message will not be altered in any way. Typically used for messages from complex sensors.
+	 * <!-- end-model-doc -->
+	 * @return the value of the '<em>Is Persistent</em>' attribute.
+	 * @see #setIsPersistent(boolean)
+	 * @see de.oaam.model.oaam.allocations.AllocationsPackage#getMessageA_IsPersistent()
+	 * @model
+	 * @generated
+	 */
+	boolean isIsPersistent();
+
+	/**
+	 * Sets the value of the '{@link de.oaam.model.oaam.allocations.MessageA#isIsPersistent <em>Is Persistent</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Is Persistent</em>' attribute.
+	 * @see #isIsPersistent()
+	 * @generated
+	 */
+	void setIsPersistent(boolean value);
+
+	/**
+	 * Returns the value of the '<em><b>Length</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * Defines length of this message
+	 * <!-- end-model-doc -->
+	 * @return the value of the '<em>Length</em>' attribute.
+	 * @see #setLength(int)
+	 * @see de.oaam.model.oaam.allocations.AllocationsPackage#getMessageA_Length()
+	 * @model
+	 * @generated
+	 */
+	int getLength();
+
+	/**
+	 * Sets the value of the '{@link de.oaam.model.oaam.allocations.MessageA#getLength <em>Length</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Length</em>' attribute.
+	 * @see #getLength()
+	 * @generated
+	 */
+	void setLength(int value);
 
 } // MessageA

--- a/de.oaam.model/src/de/oaam/model/oaam/allocations/impl/AllocationsPackageImpl.java
+++ b/de.oaam.model/src/de/oaam/model/oaam/allocations/impl/AllocationsPackageImpl.java
@@ -1022,6 +1022,24 @@ public class AllocationsPackageImpl extends EPackageImpl implements AllocationsP
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	public EAttribute getMessageA_IsPersistent() {
+		return (EAttribute)messageAEClass.getEStructuralFeatures().get(5);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getMessageA_Length() {
+		return (EAttribute)messageAEClass.getEStructuralFeatures().get(6);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	public AllocationsFactory getAllocationsFactory() {
 		return (AllocationsFactory)getEFactoryInstance();
 	}
@@ -1113,6 +1131,8 @@ public class AllocationsPackageImpl extends EPackageImpl implements AllocationsP
 		createEReference(messageAEClass, MESSAGE_A__SIGNAL_TO_MESSAGE_ASSIGNMENTS);
 		createEReference(messageAEClass, MESSAGE_A__SEGMENTS);
 		createEReference(messageAEClass, MESSAGE_A__TYPE);
+		createEAttribute(messageAEClass, MESSAGE_A__IS_PERSISTENT);
+		createEAttribute(messageAEClass, MESSAGE_A__LENGTH);
 
 		messageSegmentEClass = createEClass(MESSAGE_SEGMENT);
 		createEReference(messageSegmentEClass, MESSAGE_SEGMENT__CAPABILITY);
@@ -1293,6 +1313,8 @@ public class AllocationsPackageImpl extends EPackageImpl implements AllocationsP
 		initEReference(getMessageA_SignalToMessageAssignments(), this.getSignalToMessageAssignment(), null, "signalToMessageAssignments", null, 0, -1, MessageA.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getMessageA_Segments(), this.getMessageSegment(), null, "segments", null, 0, -1, MessageA.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getMessageA_Type(), theLibraryPackage.getMessageType(), null, "type", null, 0, 1, MessageA.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getMessageA_IsPersistent(), ecorePackage.getEBoolean(), "isPersistent", null, 0, 1, MessageA.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getMessageA_Length(), ecorePackage.getEInt(), "length", null, 0, 1, MessageA.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(messageSegmentEClass, MessageSegment.class, "MessageSegment", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getMessageSegment_Capability(), theCapabilitiesPackage.getMessageOnConnectionOrDeviceCapability(), null, "capability", null, 1, 1, MessageSegment.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);

--- a/de.oaam.model/src/de/oaam/model/oaam/allocations/impl/MessageAImpl.java
+++ b/de.oaam.model/src/de/oaam/model/oaam/allocations/impl/MessageAImpl.java
@@ -48,6 +48,8 @@ import org.eclipse.emf.ecore.util.InternalEList;
  *   <li>{@link de.oaam.model.oaam.allocations.impl.MessageAImpl#getSignalToMessageAssignments <em>Signal To Message Assignments</em>}</li>
  *   <li>{@link de.oaam.model.oaam.allocations.impl.MessageAImpl#getSegments <em>Segments</em>}</li>
  *   <li>{@link de.oaam.model.oaam.allocations.impl.MessageAImpl#getType <em>Type</em>}</li>
+ *   <li>{@link de.oaam.model.oaam.allocations.impl.MessageAImpl#isIsPersistent <em>Is Persistent</em>}</li>
+ *   <li>{@link de.oaam.model.oaam.allocations.impl.MessageAImpl#getLength <em>Length</em>}</li>
  * </ul>
  *
  * @generated
@@ -122,6 +124,46 @@ public abstract class MessageAImpl extends OaamBaseElementAImpl implements Messa
 	 * @ordered
 	 */
 	protected MessageType type;
+
+	/**
+	 * The default value of the '{@link #isIsPersistent() <em>Is Persistent</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #isIsPersistent()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final boolean IS_PERSISTENT_EDEFAULT = false;
+
+	/**
+	 * The cached value of the '{@link #isIsPersistent() <em>Is Persistent</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #isIsPersistent()
+	 * @generated
+	 * @ordered
+	 */
+	protected boolean isPersistent = IS_PERSISTENT_EDEFAULT;
+
+	/**
+	 * The default value of the '{@link #getLength() <em>Length</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getLength()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final int LENGTH_EDEFAULT = 0;
+
+	/**
+	 * The cached value of the '{@link #getLength() <em>Length</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getLength()
+	 * @generated
+	 * @ordered
+	 */
+	protected int length = LENGTH_EDEFAULT;
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -257,6 +299,48 @@ public abstract class MessageAImpl extends OaamBaseElementAImpl implements Messa
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	public boolean isIsPersistent() {
+		return isPersistent;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public void setIsPersistent(boolean newIsPersistent) {
+		boolean oldIsPersistent = isPersistent;
+		isPersistent = newIsPersistent;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, AllocationsPackage.MESSAGE_A__IS_PERSISTENT, oldIsPersistent, isPersistent));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public int getLength() {
+		return length;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public void setLength(int newLength) {
+		int oldLength = length;
+		length = newLength;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, AllocationsPackage.MESSAGE_A__LENGTH, oldLength, length));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	@Override
 	public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
 		switch (featureID) {
@@ -297,6 +381,10 @@ public abstract class MessageAImpl extends OaamBaseElementAImpl implements Messa
 			case AllocationsPackage.MESSAGE_A__TYPE:
 				if (resolve) return getType();
 				return basicGetType();
+			case AllocationsPackage.MESSAGE_A__IS_PERSISTENT:
+				return isIsPersistent();
+			case AllocationsPackage.MESSAGE_A__LENGTH:
+				return getLength();
 		}
 		return super.eGet(featureID, resolve, coreType);
 	}
@@ -337,6 +425,12 @@ public abstract class MessageAImpl extends OaamBaseElementAImpl implements Messa
 			case AllocationsPackage.MESSAGE_A__TYPE:
 				setType((MessageType)newValue);
 				return;
+			case AllocationsPackage.MESSAGE_A__IS_PERSISTENT:
+				setIsPersistent((Boolean)newValue);
+				return;
+			case AllocationsPackage.MESSAGE_A__LENGTH:
+				setLength((Integer)newValue);
+				return;
 		}
 		super.eSet(featureID, newValue);
 	}
@@ -370,6 +464,12 @@ public abstract class MessageAImpl extends OaamBaseElementAImpl implements Messa
 			case AllocationsPackage.MESSAGE_A__TYPE:
 				setType((MessageType)null);
 				return;
+			case AllocationsPackage.MESSAGE_A__IS_PERSISTENT:
+				setIsPersistent(IS_PERSISTENT_EDEFAULT);
+				return;
+			case AllocationsPackage.MESSAGE_A__LENGTH:
+				setLength(LENGTH_EDEFAULT);
+				return;
 		}
 		super.eUnset(featureID);
 	}
@@ -396,6 +496,10 @@ public abstract class MessageAImpl extends OaamBaseElementAImpl implements Messa
 				return segments != null && !segments.isEmpty();
 			case AllocationsPackage.MESSAGE_A__TYPE:
 				return type != null;
+			case AllocationsPackage.MESSAGE_A__IS_PERSISTENT:
+				return isPersistent != IS_PERSISTENT_EDEFAULT;
+			case AllocationsPackage.MESSAGE_A__LENGTH:
+				return length != LENGTH_EDEFAULT;
 		}
 		return super.eIsSet(featureID);
 	}
@@ -442,6 +546,24 @@ public abstract class MessageAImpl extends OaamBaseElementAImpl implements Messa
 			}
 		}
 		return super.eDerivedStructuralFeatureID(baseFeatureID, baseClass);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String toString() {
+		if (eIsProxy()) return super.toString();
+
+		StringBuilder result = new StringBuilder(super.toString());
+		result.append(" (isPersistent: ");
+		result.append(isPersistent);
+		result.append(", length: ");
+		result.append(length);
+		result.append(')');
+		return result.toString();
 	}
 
 } //MessageAImpl

--- a/de.oaam.model/src/de/oaam/model/oaam/common/Boolean.java
+++ b/de.oaam.model/src/de/oaam/model/oaam/common/Boolean.java
@@ -12,10 +12,42 @@ package de.oaam.model.oaam.common;
  * A Boolean value, i.e. true or false.
  * <!-- end-model-doc -->
  *
+ * <p>
+ * The following features are supported:
+ * </p>
+ * <ul>
+ *   <li>{@link de.oaam.model.oaam.common.Boolean#getNBits <em>NBits</em>}</li>
+ * </ul>
  *
  * @see de.oaam.model.oaam.common.CommonPackage#getBoolean()
  * @model
  * @generated
  */
 public interface Boolean extends DataTypeA {
+
+	/**
+	 * Returns the value of the '<em><b>NBits</b></em>' attribute.
+	 * The default value is <code>"1"</code>.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * The number of character encoding bits. The default is 8.
+	 * <!-- end-model-doc -->
+	 * @return the value of the '<em>NBits</em>' attribute.
+	 * @see #setNBits(int)
+	 * @see de.oaam.model.oaam.common.CommonPackage#getBoolean_NBits()
+	 * @model default="1" required="true"
+	 * @generated
+	 */
+	int getNBits();
+
+	/**
+	 * Sets the value of the '{@link de.oaam.model.oaam.common.Boolean#getNBits <em>NBits</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>NBits</em>' attribute.
+	 * @see #getNBits()
+	 * @generated
+	 */
+	void setNBits(int value);
 } // Boolean

--- a/de.oaam.model/src/de/oaam/model/oaam/common/Byte.java
+++ b/de.oaam.model/src/de/oaam/model/oaam/common/Byte.java
@@ -12,10 +12,42 @@ package de.oaam.model.oaam.common;
  * 8 Bits of unknown content
  * <!-- end-model-doc -->
  *
+ * <p>
+ * The following features are supported:
+ * </p>
+ * <ul>
+ *   <li>{@link de.oaam.model.oaam.common.Byte#getNBits <em>NBits</em>}</li>
+ * </ul>
  *
  * @see de.oaam.model.oaam.common.CommonPackage#getByte()
  * @model
  * @generated
  */
 public interface Byte extends DataTypeA {
+
+	/**
+	 * Returns the value of the '<em><b>NBits</b></em>' attribute.
+	 * The default value is <code>"8"</code>.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * The number of character encoding bits. The default is 8.
+	 * <!-- end-model-doc -->
+	 * @return the value of the '<em>NBits</em>' attribute.
+	 * @see #setNBits(int)
+	 * @see de.oaam.model.oaam.common.CommonPackage#getByte_NBits()
+	 * @model default="8" required="true"
+	 * @generated
+	 */
+	int getNBits();
+
+	/**
+	 * Sets the value of the '{@link de.oaam.model.oaam.common.Byte#getNBits <em>NBits</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>NBits</em>' attribute.
+	 * @see #getNBits()
+	 * @generated
+	 */
+	void setNBits(int value);
 } // Byte

--- a/de.oaam.model/src/de/oaam/model/oaam/common/CommonPackage.java
+++ b/de.oaam.model/src/de/oaam/model/oaam/common/CommonPackage.java
@@ -1651,13 +1651,22 @@ public interface CommonPackage extends EPackage {
 	int BYTE__TRACE_LINK = DATA_TYPE_A__TRACE_LINK;
 
 	/**
+	 * The feature id for the '<em><b>NBits</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int BYTE__NBITS = DATA_TYPE_A_FEATURE_COUNT + 0;
+
+	/**
 	 * The number of structural features of the '<em>Byte</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int BYTE_FEATURE_COUNT = DATA_TYPE_A_FEATURE_COUNT + 0;
+	int BYTE_FEATURE_COUNT = DATA_TYPE_A_FEATURE_COUNT + 1;
 
 	/**
 	 * The number of operations of the '<em>Byte</em>' class.
@@ -1869,13 +1878,22 @@ public interface CommonPackage extends EPackage {
 	int BOOLEAN__TRACE_LINK = DATA_TYPE_A__TRACE_LINK;
 
 	/**
+	 * The feature id for the '<em><b>NBits</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int BOOLEAN__NBITS = DATA_TYPE_A_FEATURE_COUNT + 0;
+
+	/**
 	 * The number of structural features of the '<em>Boolean</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int BOOLEAN_FEATURE_COUNT = DATA_TYPE_A_FEATURE_COUNT + 0;
+	int BOOLEAN_FEATURE_COUNT = DATA_TYPE_A_FEATURE_COUNT + 1;
 
 	/**
 	 * The number of operations of the '<em>Boolean</em>' class.
@@ -2376,6 +2394,17 @@ public interface CommonPackage extends EPackage {
 	EClass getByte();
 
 	/**
+	 * Returns the meta object for the attribute '{@link de.oaam.model.oaam.common.Byte#getNBits <em>NBits</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>NBits</em>'.
+	 * @see de.oaam.model.oaam.common.Byte#getNBits()
+	 * @see #getByte()
+	 * @generated
+	 */
+	EAttribute getByte_NBits();
+
+	/**
 	 * Returns the meta object for class '{@link de.oaam.model.oaam.common.Character <em>Character</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -2416,6 +2445,17 @@ public interface CommonPackage extends EPackage {
 	 * @generated
 	 */
 	EClass getBoolean();
+
+	/**
+	 * Returns the meta object for the attribute '{@link de.oaam.model.oaam.common.Boolean#getNBits <em>NBits</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>NBits</em>'.
+	 * @see de.oaam.model.oaam.common.Boolean#getNBits()
+	 * @see #getBoolean()
+	 * @generated
+	 */
+	EAttribute getBoolean_NBits();
 
 	/**
 	 * Returns the meta object for enum '{@link de.oaam.model.oaam.common.BoolOperationTypesE <em>Bool Operation Types E</em>}'.
@@ -2845,6 +2885,14 @@ public interface CommonPackage extends EPackage {
 		EClass BYTE = eINSTANCE.getByte();
 
 		/**
+		 * The meta object literal for the '<em><b>NBits</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute BYTE__NBITS = eINSTANCE.getByte_NBits();
+
+		/**
 		 * The meta object literal for the '{@link de.oaam.model.oaam.common.impl.CharacterImpl <em>Character</em>}' class.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
@@ -2879,6 +2927,14 @@ public interface CommonPackage extends EPackage {
 		 * @generated
 		 */
 		EClass BOOLEAN = eINSTANCE.getBoolean();
+
+		/**
+		 * The meta object literal for the '<em><b>NBits</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute BOOLEAN__NBITS = eINSTANCE.getBoolean_NBits();
 
 		/**
 		 * The meta object literal for the '{@link de.oaam.model.oaam.common.BoolOperationTypesE <em>Bool Operation Types E</em>}' enum.

--- a/de.oaam.model/src/de/oaam/model/oaam/common/impl/BooleanImpl.java
+++ b/de.oaam.model/src/de/oaam/model/oaam/common/impl/BooleanImpl.java
@@ -4,16 +4,44 @@ package de.oaam.model.oaam.common.impl;
 
 import de.oaam.model.oaam.common.CommonPackage;
 
+import java.lang.Integer;
+import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.impl.ENotificationImpl;
 
 /**
  * <!-- begin-user-doc -->
  * An implementation of the model object '<em><b>Boolean</b></em>'.
  * <!-- end-user-doc -->
+ * <p>
+ * The following features are implemented:
+ * </p>
+ * <ul>
+ *   <li>{@link de.oaam.model.oaam.common.impl.BooleanImpl#getNBits <em>NBits</em>}</li>
+ * </ul>
  *
  * @generated
  */
 public class BooleanImpl extends DataTypeAImpl implements de.oaam.model.oaam.common.Boolean {
+	/**
+	 * The default value of the '{@link #getNBits() <em>NBits</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getNBits()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final int NBITS_EDEFAULT = 1;
+	/**
+	 * The cached value of the '{@link #getNBits() <em>NBits</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getNBits()
+	 * @generated
+	 * @ordered
+	 */
+	protected int nBits = NBITS_EDEFAULT;
+
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -31,6 +59,101 @@ public class BooleanImpl extends DataTypeAImpl implements de.oaam.model.oaam.com
 	@Override
 	protected EClass eStaticClass() {
 		return CommonPackage.Literals.BOOLEAN;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public int getNBits() {
+		return nBits;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public void setNBits(int newNBits) {
+		int oldNBits = nBits;
+		nBits = newNBits;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CommonPackage.BOOLEAN__NBITS, oldNBits, nBits));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public Object eGet(int featureID, boolean resolve, boolean coreType) {
+		switch (featureID) {
+			case CommonPackage.BOOLEAN__NBITS:
+				return getNBits();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void eSet(int featureID, Object newValue) {
+		switch (featureID) {
+			case CommonPackage.BOOLEAN__NBITS:
+				setNBits((Integer)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void eUnset(int featureID) {
+		switch (featureID) {
+			case CommonPackage.BOOLEAN__NBITS:
+				setNBits(NBITS_EDEFAULT);
+				return;
+		}
+		super.eUnset(featureID);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public boolean eIsSet(int featureID) {
+		switch (featureID) {
+			case CommonPackage.BOOLEAN__NBITS:
+				return nBits != NBITS_EDEFAULT;
+		}
+		return super.eIsSet(featureID);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String toString() {
+		if (eIsProxy()) return super.toString();
+
+		StringBuilder result = new StringBuilder(super.toString());
+		result.append(" (nBits: ");
+		result.append(nBits);
+		result.append(')');
+		return result.toString();
 	}
 
 } //BooleanImpl

--- a/de.oaam.model/src/de/oaam/model/oaam/common/impl/ByteImpl.java
+++ b/de.oaam.model/src/de/oaam/model/oaam/common/impl/ByteImpl.java
@@ -4,16 +4,44 @@ package de.oaam.model.oaam.common.impl;
 
 import de.oaam.model.oaam.common.CommonPackage;
 
+import java.lang.Integer;
+import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.impl.ENotificationImpl;
 
 /**
  * <!-- begin-user-doc -->
  * An implementation of the model object '<em><b>Byte</b></em>'.
  * <!-- end-user-doc -->
+ * <p>
+ * The following features are implemented:
+ * </p>
+ * <ul>
+ *   <li>{@link de.oaam.model.oaam.common.impl.ByteImpl#getNBits <em>NBits</em>}</li>
+ * </ul>
  *
  * @generated
  */
 public class ByteImpl extends DataTypeAImpl implements de.oaam.model.oaam.common.Byte {
+	/**
+	 * The default value of the '{@link #getNBits() <em>NBits</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getNBits()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final int NBITS_EDEFAULT = 8;
+	/**
+	 * The cached value of the '{@link #getNBits() <em>NBits</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getNBits()
+	 * @generated
+	 * @ordered
+	 */
+	protected int nBits = NBITS_EDEFAULT;
+
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -31,6 +59,101 @@ public class ByteImpl extends DataTypeAImpl implements de.oaam.model.oaam.common
 	@Override
 	protected EClass eStaticClass() {
 		return CommonPackage.Literals.BYTE;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public int getNBits() {
+		return nBits;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public void setNBits(int newNBits) {
+		int oldNBits = nBits;
+		nBits = newNBits;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CommonPackage.BYTE__NBITS, oldNBits, nBits));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public Object eGet(int featureID, boolean resolve, boolean coreType) {
+		switch (featureID) {
+			case CommonPackage.BYTE__NBITS:
+				return getNBits();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void eSet(int featureID, Object newValue) {
+		switch (featureID) {
+			case CommonPackage.BYTE__NBITS:
+				setNBits((Integer)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void eUnset(int featureID) {
+		switch (featureID) {
+			case CommonPackage.BYTE__NBITS:
+				setNBits(NBITS_EDEFAULT);
+				return;
+		}
+		super.eUnset(featureID);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public boolean eIsSet(int featureID) {
+		switch (featureID) {
+			case CommonPackage.BYTE__NBITS:
+				return nBits != NBITS_EDEFAULT;
+		}
+		return super.eIsSet(featureID);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String toString() {
+		if (eIsProxy()) return super.toString();
+
+		StringBuilder result = new StringBuilder(super.toString());
+		result.append(" (nBits: ");
+		result.append(nBits);
+		result.append(')');
+		return result.toString();
 	}
 
 } //ByteImpl

--- a/de.oaam.model/src/de/oaam/model/oaam/common/impl/CommonPackageImpl.java
+++ b/de.oaam.model/src/de/oaam/model/oaam/common/impl/CommonPackageImpl.java
@@ -711,6 +711,15 @@ public class CommonPackageImpl extends EPackageImpl implements CommonPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	public EAttribute getByte_NBits() {
+		return (EAttribute)byteEClass.getEStructuralFeatures().get(0);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	public EClass getCharacter() {
 		return characterEClass;
 	}
@@ -740,6 +749,15 @@ public class CommonPackageImpl extends EPackageImpl implements CommonPackage {
 	 */
 	public EClass getBoolean() {
 		return booleanEClass;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getBoolean_NBits() {
+		return (EAttribute)booleanEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
@@ -854,12 +872,14 @@ public class CommonPackageImpl extends EPackageImpl implements CommonPackage {
 		createEAttribute(floatingPointEClass, FLOATING_POINT__ENDIANESS);
 
 		byteEClass = createEClass(BYTE);
+		createEAttribute(byteEClass, BYTE__NBITS);
 
 		characterEClass = createEClass(CHARACTER);
 		createEAttribute(characterEClass, CHARACTER__ENCODING);
 		createEAttribute(characterEClass, CHARACTER__NBITS);
 
 		booleanEClass = createEClass(BOOLEAN);
+		createEAttribute(booleanEClass, BOOLEAN__NBITS);
 
 		// Create enums
 		boolOperationTypesEEEnum = createEEnum(BOOL_OPERATION_TYPES_E);
@@ -971,12 +991,14 @@ public class CommonPackageImpl extends EPackageImpl implements CommonPackage {
 		initEAttribute(getFloatingPoint_Endianess(), this.getEndianessE(), "endianess", "BIG", 1, 1, FloatingPoint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(byteEClass, de.oaam.model.oaam.common.Byte.class, "Byte", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getByte_NBits(), ecorePackage.getEInt(), "nBits", "8", 1, 1, de.oaam.model.oaam.common.Byte.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(characterEClass, de.oaam.model.oaam.common.Character.class, "Character", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEAttribute(getCharacter_Encoding(), ecorePackage.getEString(), "encoding", null, 1, 1, de.oaam.model.oaam.common.Character.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getCharacter_NBits(), ecorePackage.getEInt(), "nBits", "8", 1, 1, de.oaam.model.oaam.common.Character.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(booleanEClass, de.oaam.model.oaam.common.Boolean.class, "Boolean", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getBoolean_NBits(), ecorePackage.getEInt(), "nBits", "1", 1, 1, de.oaam.model.oaam.common.Boolean.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		// Initialize enums and add enum literals
 		initEEnum(boolOperationTypesEEEnum, BoolOperationTypesE.class, "BoolOperationTypesE");


### PR DESCRIPTION
This PR adds NBits attribute to Boolean and Byte datatype.
Although being obvious, it comes in handy when trying to determine the signal length without hardcoding it into transformations.